### PR TITLE
Switch the end chomping to be absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple tool for chomping the ends of a VTT file.
 Uploading a meeting video and want to get rid of the first 5 minutes where you're waiting for everyone to join?
 Use the `-b <SECONDS>` argument to chomp that many seconds off the beginning of the VTT file and update the time stamps accordingly.
 Want to trim off the end where everyone's just awkwardly saying goodbye to each other?
-use the `-e <SECONDS>` argument to chomp that many seconds off the end of the VTT file.
+use the `-e <SECONDS>` argument to chomp beyond that timestamp in the VTT file.
 Very tasty!
 
 ## Requirements

--- a/src/vtt-chomper/vtt-chomper.py
+++ b/src/vtt-chomper/vtt-chomper.py
@@ -64,8 +64,8 @@ def main():
     argparser.add_argument(
         "-e", "--end",
         dest="trimEnd",
-        help="Seconds to trim from the end",
-        default=0,
+        help="Ending timestamp in seconds",
+        default=-1,
         type=int
     )
     argparser.add_argument(
@@ -89,10 +89,13 @@ def main():
     inVtt = webvtt.read(options.inputFile)
     outVtt = webvtt.WebVTT()
 
-    # If we're chomping off the back, check to see what the final timestamp is.
-    # If we're not chomping off the back, use the final timestamp as the
-    # chomping point.
-    lastTimestamp = timestamp_to_ms(inVtt.captions[-1].end) - (options.trimEnd * 1000)
+    # If we're chomping off the end, just use the value provided.
+    # If we're not chomping off the end, use the final timestamp as the
+    # comparison point for chomping.
+    if options.trimEnd == -1:
+        lastTimestamp = timestamp_to_ms(inVtt.captions[-1].end)
+    else:
+        lastTimestamp = options.trimEnd * 1000
 
     for caption in inVtt.captions:
         startTime = timestamp_to_ms(caption.start)


### PR DESCRIPTION
Relative turns out to be buggy because the last time stamp in the video isn't necessarily the last time stamp in the VTT file.

Fixes #8 